### PR TITLE
Fix checking for changes using `git diff`

### DIFF
--- a/autoupdate-dependencies.sh
+++ b/autoupdate-dependencies.sh
@@ -58,7 +58,8 @@ fi
 echo "Running update command $update_command"
 eval $update_command
 
-if [ -n "git diff" ]
+git diff --exit-code >/dev/null 2>&1
+if [ $? = 1 ]
 then
     echo "Updates detected"
 


### PR DESCRIPTION
`git-diff` prints out a newline even when there is no diff.

The more robust way is to use `--exit-code`, which makes `git-diff` to return `1` if there are changes, `0` if there is none.