### PR TITLE
fix: use a static username

### DIFF
--- a/autoupdate-dependencies.sh
+++ b/autoupdate-dependencies.sh
@@ -9,7 +9,7 @@ pr_branch=$3
 update_path=$4
 on_changes_command=$5
 repo=$GITHUB_REPOSITORY #owner and repository: ie: user/repo
-username=$GITHUB_ACTOR
+username="dependencies-autoupdate"
 
 branch_name="automated-dependencies-update"
 email="noreply@github.com"


### PR DESCRIPTION
`$GITHUB_ACTOR` is the github account that enabled the github action in a specific repo

For repo that are used by a team, it does not make sense to attribute the autoupdate commits to a single member

This commit changes the behavior to simply use `dependencies-autoupdate` as a commit author