### PR TITLE
refact(default): set defaults in the action.yml file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,7 @@ inputs:
   pr-branch:
     description: PR branch against which the PR should be created, defaults to main
     required: false
+    default: main
   update-path:
     description: Path to directory to run the update-command. If not provided defaults to root
     required: false

--- a/autoupdate-dependencies.sh
+++ b/autoupdate-dependencies.sh
@@ -24,11 +24,6 @@ if [ -z "$update_command" ]; then
     exit 1
 fi
 
-if [ -z "$pr_branch" ]; then
-    echo "pr-branch not set, falling back to `main`"
-    pr_branch="main"
-fi
-
 # remove optional params markers
 update_path_value=${update_path%?}
 if [ -n "$update_path_value" ]; then


### PR DESCRIPTION
The default can be set in the àction.yml` file itself: https://docs.github.com/en/actions/reference/metadata-syntax-for-github-actions#inputsinput_iddefault

This commit simplifies the code accordingly